### PR TITLE
Moving from os.path to pathlib.Path

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -39,7 +39,7 @@ for file_path in Path(input_directory).rglob("*.md"):
     text.content = data['translatedText']
 
     # create output subdirectory if it doesn't exist
-    relative_file_path = file_path.relative_to(input_directory)
+    relative_file_path = file_path.parent.relative_to(input_directory)
     write_directory = output_directory / relative_file_path
     write_directory.mkdir(parents=True, exist_ok=True)
     

--- a/translate.py
+++ b/translate.py
@@ -5,51 +5,46 @@
 # @purpose: Sends batches of Markdown files to a locally-running LibreTranslate API and outputs translated Markdown files
 # @acknowledgements:
 
-import requests
 import json
-import frontmatter
-import os
+from pathlib import Path
+
+import requests
+import frontmatter  # pip install python-frontmatter
 
 # variables
 input_language = 'en'
 output_language = 'eo'
 url = "http://localhost:5000/translate"
-base_directory = '/Users/ad7588/projects/copim_website_inate/copim_website/content/'
-input_directory = base_directory + input_language + '/'
-output_directory = base_directory + output_language + '/'
+base_directory = Path('/Users/ad7588/projects/copim_website_inate/copim_website/content/')
+input_directory = base_directory / input_language 
+output_directory = base_directory / output_language
  
-# iterate over files in the input directory
-for subdir, dirs, files in os.walk(input_directory):
-    for file in files:
-        # file name with extension
-        file_name = os.path.basename(file)
-        read_file = subdir + '/' + file_name
+# iterate over files with .md suffix in the input directory
+for file_path in Path(input_directory).rglob("*.md"):    
+    # read Markdown file
+    text = frontmatter.load(file_path)
 
-        # read Markdown file
-        text = frontmatter.load(read_file)
+    # send content of Markdown file to LibreTranslate API
+    payload = {
+        "q": text.content,
+        "source": input_language,
+        "target": output_language,
+        "format": "text",
+        "api_key": ""
+    }
+    headers = {"Content-Type": "application/json"}
+    
+    response = requests.post(url, data=json.dumps(payload), headers=headers)
+    data = response.json()
+    text.content = data['translatedText']
 
-        # send content of Markdown file to LibreTranslate API
-        payload = {
-            "q": text.content,
-            "source": input_language,
-            "target": output_language,
-            "format": "text",
-            "api_key": ""
-        }
-        headers = {"Content-Type": "application/json"}
-
-        response = requests.post(url, data=json.dumps(payload), headers=headers)
-        data = response.json()
-        text.content = data['translatedText']
-
-        write_directory = subdir.replace(input_directory, output_directory)
-        # Check if the output directory exists
-        if not os.path.exists(write_directory):  
-            # If it doesn't exist, create it
-            os.makedirs(write_directory)
-
-        write_file = write_directory + '/' + file_name
-
-        # write new Markdown file
-        with open(write_file, 'w') as f:
-            f.write(frontmatter.dumps(text))
+    # create output subdirectory if it doesn't exist
+    relative_file_path = file_path.relative_to(input_directory)
+    write_directory = output_directory / relative_file_path
+    write_directory.parent.mkdir(parents=True, exist_ok=True)
+    
+    write_file_path = write_directory / file_path.name
+ 
+    # write new Markdown file
+    with open(write_file_path, 'w') as f:
+        f.write(frontmatter.dumps(text))

--- a/translate.py
+++ b/translate.py
@@ -41,7 +41,7 @@ for file_path in Path(input_directory).rglob("*.md"):
     # create output subdirectory if it doesn't exist
     relative_file_path = file_path.relative_to(input_directory)
     write_directory = output_directory / relative_file_path
-    write_directory.parent.mkdir(parents=True, exist_ok=True)
+    write_directory.mkdir(parents=True, exist_ok=True)
     
     write_file_path = write_directory / file_path.name
  


### PR DESCRIPTION
See if this makes any sense...  ref: https://github.com/SimonXIX/Markdown_translation/issues/1

I have also:
- Added the ".md" restriction to the rglob() search...  
- Reordered the imports and added a comment about the frontmatter module having a different name on PyPI